### PR TITLE
Add dark themed landing page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
-# bridgeweb
+# AgentBridge Web
+
+Simple landing page for **AgentBridge** showcasing custom AI agent services.
+
+## Features
+- Modern dark theme with Tailwind CSS
+- Responsive design for mobile and desktop
+- Sections for features and contact
+
+## Getting Started
+Open `src/index.html` in a browser to view the page. No build step or dependencies are required since assets are loaded via CDN.

--- a/src/index.html
+++ b/src/index.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>AgentBridge - Custom AI Agents</title>
+  <link href="https://cdn.jsdelivr.net/npm/tailwindcss@^3/dist/tailwind.min.css" rel="stylesheet">
+  <style>
+    body {background-color: #0f0f0f; color: #f5f5f5; font-family: 'Inter', sans-serif;}
+  </style>
+</head>
+<body class="min-h-screen flex flex-col">
+  <header class="py-6">
+    <div class="container mx-auto px-4 flex justify-between items-center">
+      <h1 class="text-3xl font-bold">AgentBridge</h1>
+      <nav>
+        <a href="#features" class="mx-2 hover:text-indigo-400">Features</a>
+        <a href="#contact" class="mx-2 hover:text-indigo-400">Contact</a>
+      </nav>
+    </div>
+  </header>
+  <main class="flex-grow">
+    <section class="py-24 text-center bg-gradient-to-b from-gray-900 to-black">
+      <div class="container mx-auto px-4">
+        <h2 class="text-4xl sm:text-5xl font-extrabold mb-4">Custom AI Agents On Demand</h2>
+        <p class="max-w-2xl mx-auto text-xl mb-8">We design, build, and deploy bespoke AI agents to automate key business workflows.</p>
+        <a href="#contact" class="inline-block bg-indigo-600 hover:bg-indigo-500 text-white py-3 px-6 rounded-lg text-lg">Get Started</a>
+      </div>
+    </section>
+    <section id="features" class="py-16">
+      <div class="container mx-auto px-4 grid sm:grid-cols-2 lg:grid-cols-3 gap-8">
+        <div class="bg-gray-800 p-6 rounded-lg shadow">
+          <h3 class="text-2xl font-semibold mb-2">Bespoke Design</h3>
+          <p>Create tailored AI agents that fit perfectly into your workflow.</p>
+        </div>
+        <div class="bg-gray-800 p-6 rounded-lg shadow">
+          <h3 class="text-2xl font-semibold mb-2">Deployment & Support</h3>
+          <p>Deploy your agent across environments with ongoing technical support.</p>
+        </div>
+        <div class="bg-gray-800 p-6 rounded-lg shadow">
+          <h3 class="text-2xl font-semibold mb-2">Workflow Automation</h3>
+          <p>Streamline complex business processes effortlessly.</p>
+        </div>
+      </div>
+    </section>
+    <section id="contact" class="py-16 bg-gray-900">
+      <div class="container mx-auto px-4 text-center">
+        <h3 class="text-3xl font-bold mb-4">Let's Build Together</h3>
+        <p class="mb-8">Reach out to automate the workflows that matter most.</p>
+        <a href="mailto:info@agentbridge.ai" class="inline-block bg-indigo-600 hover:bg-indigo-500 text-white py-3 px-6 rounded-lg text-lg">Contact Us</a>
+      </div>
+    </section>
+  </main>
+  <footer class="py-6 text-center bg-black">
+    <p class="text-sm">&copy; 2024 AgentBridge. All rights reserved.</p>
+  </footer>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a Tailwind-based landing page for AgentBridge
- document features and usage in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683ffd06f90c8325859b3b8bed7c6331